### PR TITLE
リファクタリング: ロジックをカスタムフックとユーティリティ関数に分離

### DIFF
--- a/src/hooks/useSelectedText.ts
+++ b/src/hooks/useSelectedText.ts
@@ -1,0 +1,47 @@
+import { getSelectedText, showToast, Toast } from "@raycast/api";
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * 選択テキストを取得するためのカスタムフック
+ * @param delayMs 選択テキスト取得前の遅延時間（ミリ秒）
+ * @returns 選択テキスト、ローディング状態、エラー状態
+ */
+export function useSelectedText(delayMs = 1) {
+  const [selectedText, setSelectedText] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 選択テキストを取得する関数
+  const fetchSelectedText = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      console.log("テキスト取得開始");
+      const text = await getSelectedText();
+      setSelectedText(text);
+      console.log(`取得したテキスト: ${text}`);
+    } catch (e) {
+      console.error("選択テキストの取得に失敗しました:", e);
+      setError("選択テキストの取得に失敗しました");
+      await showToast({
+        style: Toast.Style.Failure,
+        title: "エラー",
+        message: "選択テキストの取得に失敗しました",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // コンポーネントがマウントされたときに実行
+  useEffect(() => {
+    // 少し遅延させて選択テキストを取得
+    const timer = setTimeout(() => {
+      fetchSelectedText();
+    }, delayMs);
+
+    return () => clearTimeout(timer);
+  }, [fetchSelectedText, delayMs]);
+
+  return { selectedText, isLoading, error, fetchSelectedText };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,55 +1,10 @@
-import { Detail, getSelectedText, showToast, Toast } from "@raycast/api";
-import { useState, useEffect, useCallback } from "react";
+import { Detail } from "@raycast/api";
+import { useSelectedText } from "./hooks/useSelectedText";
+import { generateMarkdown } from "./utils/markdown";
 
 export default function Command() {
-  const [selectedText, setSelectedText] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  // 選択テキストを取得する関数
-  const fetchSelectedText = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      setError(null);
-      console.log("テキスト取得開始");
-      const text = await getSelectedText();
-      setSelectedText(text);
-      console.log(`取得したテキスト: ${text}`);
-    } catch (e) {
-      console.error("選択テキストの取得に失敗しました:", e);
-      setError("選択テキストの取得に失敗しました");
-      await showToast({
-        style: Toast.Style.Failure,
-        title: "エラー",
-        message: "選択テキストの取得に失敗しました",
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  // MEMO: 1ミリ秒でも遅延させると、テキスト取得ができるっぽい？（ここまででコミットしておきたいな）
-  // コンポーネントがマウントされたときに実行
-  useEffect(() => {
-    // 少し遅延させて選択テキストを取得
-    const timer = setTimeout(() => {
-      fetchSelectedText();
-    }, 1); // 500ミリ秒の遅延を追加
-
-    return () => clearTimeout(timer);
-  }, [fetchSelectedText]);
-
-  let markdown = "# 選択テキスト取得テスト\n\n";
-
-  if (isLoading) {
-    markdown += "選択テキストを取得中...";
-  } else if (error) {
-    markdown += `## エラー\n\n${error}`;
-  } else if (!selectedText) {
-    markdown += "選択されたテキストがありません。テキストを選択してから再試行してください。";
-  } else {
-    markdown += `## 選択されたテキスト\n\n\`\`\`\n${selectedText}\n\`\`\``;
-  }
+  const { selectedText, isLoading, error } = useSelectedText();
+  const markdown = generateMarkdown(selectedText, isLoading, error);
 
   return <Detail markdown={markdown} isLoading={isLoading} />;
 }

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,22 @@
+/**
+ * 選択テキストの状態に基づいてマークダウンを生成する
+ * @param selectedText 選択テキスト
+ * @param isLoading ローディング状態
+ * @param error エラー状態
+ * @returns マークダウン文字列
+ */
+export function generateMarkdown(selectedText: string | null, isLoading: boolean, error: string | null): string {
+  let markdown = "# 選択テキスト取得テスト\n\n";
+
+  if (isLoading) {
+    markdown += "選択テキストを取得中...";
+  } else if (error) {
+    markdown += `## エラー\n\n${error}`;
+  } else if (!selectedText) {
+    markdown += "選択されたテキストがありません。テキストを選択してから再試行してください。";
+  } else {
+    markdown += `## 選択されたテキスト\n\n\`\`\`\n${selectedText}\n\`\`\``;
+  }
+
+  return markdown;
+}


### PR DESCRIPTION
## 変更内容

- 選択テキスト取得ロジックを  カスタムフックに分離
- マークダウン生成ロジックを  ユーティリティ関数に分離
- メインコンポーネントをシンプルに保つことで可読性と保守性を向上

## 動作確認

- 選択テキストの取得機能が正常に動作することを確認済み

## 関連Issue

- 関連: #1 (このPRではIssue自体は解決していませんが、今後の実装の基盤となります)
