### PR TITLE
翻訳先の言語をカスタムできるようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,14 @@
       "type": "password",
       "placeholder": "sk-...",
       "required": true
+    },
+    {
+      "name": "targetLanguage",
+      "title": "Target Language",
+      "description": "Language to translate to (e.g. Japanese, English, French, Chinese, etc.)",
+      "type": "textfield",
+      "placeholder": "Japanese, English, French, Chinese, etc.",
+      "required": true
     }
   ],
   "dependencies": {

--- a/src/ai-translate.tsx
+++ b/src/ai-translate.tsx
@@ -1,5 +1,5 @@
 import { useAI } from "@/utils/hooks/useAI";
-import { Detail, LaunchProps, ActionPanel, Action, Icon } from "@raycast/api";
+import { Detail, LaunchProps, ActionPanel, Action, Icon, openExtensionPreferences } from "@raycast/api";
 
 /**
  * 入力テキストをAI翻訳して結果を表示するコマンド
@@ -11,7 +11,11 @@ export default function Command(props: LaunchProps) {
 
   return (
     <Detail
-      markdown={error ? "🚨 An error occurred during translation. Please try again." : translatedText}
+      markdown={
+        error
+          ? `🚨 An error occurred during translation. Please try again.\n\n\`\`\`\n${error}\n\`\`\``
+          : translatedText
+      }
       isLoading={isLoading}
       actions={
         isLoading ? null : (
@@ -32,8 +36,15 @@ export default function Command(props: LaunchProps) {
             )}
             <Action.OpenInBrowser
               title="Open Usage Dashboard"
-              url="https://platform.openai.com/settings/organization/usage"
               icon={Icon.BarChart}
+              url="https://platform.openai.com/settings/organization/usage"
+              shortcut={{ modifiers: ["cmd"], key: "u" }}
+            />
+            <Action
+              title="Open Extension Preferences"
+              icon={Icon.Gear}
+              onAction={openExtensionPreferences}
+              shortcut={{ modifiers: ["cmd"], key: "e" }}
             />
           </ActionPanel>
         )


### PR DESCRIPTION
## 概要

Issue #7 の実装として、翻訳先の言語をカスタムできるようにしました。

## 変更内容

- package.json に targetLanguage 設定項目を追加しました
- useAI フックを修正して設定項目から翻訳先言語を取得するようにしました
- プロンプトインジェクション対策として、入力された言語名を 20 文字に制限するサニタイズ処理を追加しました
- エラー表示の改善と設定画面へのアクセスを容易にする UI の変更を行いました

これにより、ユーザーは任意の言語に翻訳できるようになります。

Closes #7
